### PR TITLE
Add assert statements to verify datetime parameters are not null upon initialisation

### DIFF
--- a/src/main/java/duke/task/Deadline.java
+++ b/src/main/java/duke/task/Deadline.java
@@ -18,6 +18,7 @@ public class Deadline extends Task {
     public Deadline(String description, String by) {
         super(description);
         this.by = new DateTime(by);
+        assert (this.by != null) : "'By' should not be null!";
     }
 
     /**

--- a/src/main/java/duke/task/Event.java
+++ b/src/main/java/duke/task/Event.java
@@ -21,6 +21,7 @@ public class Event extends Task {
         super(description);
         this.from = new DateTime(from);
         this.to = new DateTime(to);
+        assert (this.from != null && this.to != null) : "'From' and 'to' should not be null!";
     }
 
     /**


### PR DESCRIPTION
This is to ensure that programmers remember to initialise deadline and event objects with datetime parameters (otherwise a todo task will suffice).